### PR TITLE
Issue 6: Misuse of textContent Instead of innerText #6

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -92,7 +92,7 @@ function addItemToDOM(text, completed) {
   var list = (completed) ? document.getElementById('completed') : document.getElementById('todo');
 
   var item = document.createElement('li');
-  item.textContent = text;
+  item.innerText = text;
 
   var buttons = document.createElement('div');
   buttons.classList.add('buttons');


### PR DESCRIPTION
"textContent" was used in the " addItemToDOM" function, which could cause issues if the item text contains HTML elements. This might break the visual rendering of the list. So used innerText to resolve this issue.